### PR TITLE
CI workflow with schedule and manual trigger

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,9 @@ on:
       - main
     tags: ['*']
   pull_request:
+  schedule:
+    - cron: '0 0 1 * *'  # Runs at midnight UTC on the 1st of every month
+  workflow_dispatch:       # Allows manual trigger from the Actions tab
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.


### PR DESCRIPTION
Added scheduled and manual triggers for CI workflow.

## Summary by Sourcery

Add additional triggers to the CI workflow configuration.

CI:
- Run the CI workflow on a monthly schedule via cron.
- Enable manual execution of the CI workflow from the Actions tab.